### PR TITLE
[PB-3763]:fix/default dropdown props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/ui",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Library of Internxt components",
   "repository": {
     "type": "git",

--- a/src/components/breadcrumbs/__test__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__test__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`Breadcrumbs Component > should match snapshot 1`] = `
                     undefined
                     undefined
                     false
-                    undefined
+                    text-gray-80
                   "
                     >
                       <div
@@ -248,7 +248,7 @@ exports[`Breadcrumbs Component > should match snapshot 1`] = `
                     undefined
                     undefined
                     false
-                    undefined
+                    text-gray-80
                   "
                   >
                     <div

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -62,7 +62,7 @@ const Dropdown = <T,>({
   classMenuItems,
   openDirection,
   dropdownActionsContext,
-  item,
+  item = {} as T,
 }: DropdownProps<T>): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const direction = openDirection === 'left' ? 'origin-top-left' : 'origin-top-right';

--- a/src/stories/components/dropdown/Dropdown.stories.tsx
+++ b/src/stories/components/dropdown/Dropdown.stories.tsx
@@ -36,7 +36,6 @@ const defaultArgs: DropdownProps<unknown> = {
     { separator: true },
     { name: 'Action 3', action: () => alert('Launched action 3') },
   ],
-  item: 'Item',
   openDirection: 'left',
 };
 


### PR DESCRIPTION
Item dropwdown prop is an empty object by default to allow options menu in case no item is provided.