### PR TITLE
[PB-4903]: add stopMouseDownPropagation prop to Modal component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/ui",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Library of Internxt components",
   "repository": {
     "type": "git",

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -8,6 +8,7 @@ export interface ModalProps {
   className?: string;
   width?: string;
   preventClosing?: boolean;
+  stopMouseDownPropagation?: boolean;
 }
 
 /**
@@ -38,6 +39,9 @@ export interface ModalProps {
  * @property {boolean} [preventClosing=false]
  * - Optional flag to prevent the modal from closing when clicking outside or pressing the 'Escape' key.
  *
+ * @property {boolean} [stopMouseDownPropagation=false]
+ * - Optional flag to stop event propagation on mousedown events.
+ *
  * @returns {JSX.Element | null}
  * - The rendered Modal component, or `null` if `isOpen` is `false`.
  *
@@ -59,6 +63,7 @@ const Modal = ({
   className,
   width,
   preventClosing = false,
+  stopMouseDownPropagation = false,
 }: ModalProps): JSX.Element | null => {
   const modalRef = useRef<HTMLDivElement | null>(null);
   const [showContent, setShowContent] = useState(isOpen);
@@ -128,7 +133,7 @@ const Modal = ({
   return (
     <>
       {showContent && (
-        <div className="m-0">
+        <div className="m-0" onMouseDown={(e) => stopMouseDownPropagation && e.stopPropagation()} role='modal'>
           <div
             className={`
               fixed

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -78,6 +78,12 @@ const Modal = ({
     }
   };
 
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (stopMouseDownPropagation) {
+      e.stopPropagation();
+    }
+  };
+
   useEffect(() => {
     if (isOpen) {
       const timeout = setTimeout(() => {
@@ -133,7 +139,7 @@ const Modal = ({
   return (
     <>
       {showContent && (
-        <div className="m-0" onMouseDown={(e) => stopMouseDownPropagation && e.stopPropagation()} role='modal'>
+        <div className="m-0" onMouseDown={handleMouseDown} role="dialog" aria-modal="true">
           <div
             className={`
               fixed

--- a/src/components/modal/__test__/Modal.test.tsx
+++ b/src/components/modal/__test__/Modal.test.tsx
@@ -207,4 +207,40 @@ describe('Modal Component', () => {
     expect(onClose1).not.toHaveBeenCalled();
     expect(onClose2).toHaveBeenCalled();
   });
+
+  it('should stop propagation when stopMouseDownPropagation is true', () => {
+    const parentHandler = vi.fn();
+    const { container } = render(
+      <div onMouseDown={parentHandler}>
+        <Modal isOpen={true} onClose={onCloseMock} stopMouseDownPropagation={true}>
+          <div>Modal Content</div>
+        </Modal>
+      </div>,
+    );
+
+    const modalWrapper = container.querySelector('[role="modal"]');
+    expect(modalWrapper).toBeInTheDocument();
+
+    fireEvent.mouseDown(modalWrapper!);
+
+    expect(parentHandler).not.toHaveBeenCalled();
+  });
+
+  it('should not stop propagation when stopMouseDownPropagation is false', () => {
+    const parentHandler = vi.fn();
+    const { container } = render(
+      <div onMouseDown={parentHandler}>
+        <Modal isOpen={true} onClose={onCloseMock} stopMouseDownPropagation={false}>
+          <div>Modal Content</div>
+        </Modal>
+      </div>,
+    );
+
+    const modalWrapper = container.querySelector('[role="modal"]');
+    expect(modalWrapper).toBeInTheDocument();
+
+    fireEvent.mouseDown(modalWrapper!);
+
+    expect(parentHandler).toHaveBeenCalled();
+  });
 });

--- a/src/components/modal/__test__/Modal.test.tsx
+++ b/src/components/modal/__test__/Modal.test.tsx
@@ -218,7 +218,7 @@ describe('Modal Component', () => {
       </div>,
     );
 
-    const modalWrapper = container.querySelector('[role="modal"]');
+    const modalWrapper = container.querySelector('[role="dialog"]');
     expect(modalWrapper).toBeInTheDocument();
 
     fireEvent.mouseDown(modalWrapper!);
@@ -236,7 +236,7 @@ describe('Modal Component', () => {
       </div>,
     );
 
-    const modalWrapper = container.querySelector('[role="modal"]');
+    const modalWrapper = container.querySelector('[role="dialog"]');
     expect(modalWrapper).toBeInTheDocument();
 
     fireEvent.mouseDown(modalWrapper!);

--- a/src/components/modal/__test__/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/modal/__test__/__snapshots__/Modal.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Modal Component > should match snapshot when isOpen is true 1`] = `
 <div>
   <div
     class="m-0"
+    role="modal"
   >
     <div
       class="

--- a/src/components/modal/__test__/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/modal/__test__/__snapshots__/Modal.test.tsx.snap
@@ -3,8 +3,9 @@
 exports[`Modal Component > should match snapshot when isOpen is true 1`] = `
 <div>
   <div
+    aria-modal="true"
     class="m-0"
-    role="modal"
+    role="dialog"
   >
     <div
       class="


### PR DESCRIPTION
Add optional stopMouseDownPropagation prop to control event propagation on mousedown events. Update role attribute to 'modal' for better accessibility and add corresponding tests.