### PR TITLE
[-]:fix/Copyable component

### DIFF
--- a/src/components/input/copyable/Copyable.tsx
+++ b/src/components/input/copyable/Copyable.tsx
@@ -51,7 +51,7 @@ const Copyable = ({
       <p className={`${classText}`}>{text}</p>
       <Tooltip
         className="ml-6"
-        popsFrom="bottom"
+        popsFrom="top"
         title={justCopied ? copiedText : copyToClipboardText}
         delayInMs={justCopied ? 500 : undefined}
       >

--- a/src/components/input/copyable/__test__/__snapshots__/Copyable.test.tsx.snap
+++ b/src/components/input/copyable/__test__/__snapshots__/Copyable.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Copyable Component > should match snapshot 1`] = `
           style="line-height: 0;"
         >
           <div
-            class="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-1.5 flex items-center flex-col-reverse drop-shadow-tooltip transition-all duration-150 scale-50 opacity-0"
+            class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 origin-bottom flex items-center flex-col drop-shadow-tooltip transition-all duration-150 scale-50 opacity-0"
           >
             <div
               class="w-max rounded-lg bg-gray-90 px-4 py-1.5 text-center dark:bg-gray-5"
@@ -32,7 +32,7 @@ exports[`Copyable Component > should match snapshot 1`] = `
             <div
               class="bg-gray-90 dark:bg-gray-5 h-1.5 w-4"
               data-testid="tooltip-arrow"
-              style="clip-path: polygon(50% 0%, 0% 100%, 100% 100%);"
+              style="clip-path: polygon(0% 0%, 100% 0%, 50% 100%); margin-top: -1px;"
             />
           </div>
           <button>
@@ -67,7 +67,7 @@ exports[`Copyable Component > should match snapshot 1`] = `
         style="line-height: 0;"
       >
         <div
-          class="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-1.5 flex items-center flex-col-reverse drop-shadow-tooltip transition-all duration-150 scale-50 opacity-0"
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 origin-bottom flex items-center flex-col drop-shadow-tooltip transition-all duration-150 scale-50 opacity-0"
         >
           <div
             class="w-max rounded-lg bg-gray-90 px-4 py-1.5 text-center dark:bg-gray-5"
@@ -81,7 +81,7 @@ exports[`Copyable Component > should match snapshot 1`] = `
           <div
             class="bg-gray-90 dark:bg-gray-5 h-1.5 w-4"
             data-testid="tooltip-arrow"
-            style="clip-path: polygon(50% 0%, 0% 100%, 100% 100%);"
+            style="clip-path: polygon(0% 0%, 100% 0%, 50% 100%); margin-top: -1px;"
           />
         </div>
         <button>


### PR DESCRIPTION
We fixed the direction the copyable tooltip displays, now by default will be displaying on top