### PR TITLE
[PB-5978]: feat(sidenav)/add notification slot above storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/ui",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Library of Internxt components",
   "repository": {
     "type": "git",

--- a/src/components/navigation/sidenav/Sidenav.tsx
+++ b/src/components/navigation/sidenav/Sidenav.tsx
@@ -1,4 +1,5 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
+import { WarningIcon } from '@phosphor-icons/react';
 import SidenavOptions, { SidenavOption } from './SidenavOptions';
 import SidenavHeader from './SidenavHeader';
 import SidenavStorage from './SidenavStorage';
@@ -39,7 +40,12 @@ export interface SidenavProps {
   showSubsections?: boolean;
   isCollapsed?: boolean;
   storage?: SidenavStorageProps;
-  notification?: ReactNode;
+  notification?: {
+    message: string;
+    actionLabel: string;
+    onAction: () => void;
+    type?: 'warning';
+  };
   onToggleCollapse?: () => void;
 }
 
@@ -56,7 +62,7 @@ export interface SidenavProps {
  * @property {boolean} showSubsections - Determines whether to display the subsections of the sidenav
  * @property {boolean} isCollapsed - Determines whether the sidenav is collapsed or not
  * @property {SidenavStorage} storage - The storage information displayed at the bottom of the sidenav
- * @property {ReactNode} notification - Optional notification node rendered above the storage section (hidden when collapsed)
+ * @property {object} notification - Optional structured notification rendered above the storage section (hidden when collapsed). Accepts message, actionLabel, onAction, and an optional type ('warning').
  * @property {() => void} onToggleCollapse - A callback function triggered when the collapse button is clicked
  */
 const Sidenav = ({
@@ -71,6 +77,21 @@ const Sidenav = ({
   notification,
   onToggleCollapse,
 }: SidenavProps) => {
+  const [showContent, setShowContent] = useState(!isCollapsed);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (isCollapsed) {
+      setShowContent(false);
+    } else {
+      timerRef.current = setTimeout(() => setShowContent(true), 300);
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [isCollapsed]);
+
   return (
     <div
       className={`relative flex flex-col p-2 h-full justify-between bg-gray-1 border-r border-gray-10 transition-all duration-300 group ${
@@ -97,11 +118,25 @@ const Sidenav = ({
         </div>
       </div>
 
-      {(notification || storage) && (
-        <div
-          className={`flex flex-col transition-all overflow-hidden duration-300 ${isCollapsed ? 'opacity-0 invisible delay-200' : 'opacity-100 delay-0'}`}
-        >
-          {notification && <div className="px-2 pb-2">{notification}</div>}
+      {(notification || storage) && showContent && (
+        <div className="flex flex-col">
+          {notification && (
+            <div className="px-2 pb-2">
+              <div className="flex gap-1.5 items-start p-3 rounded-lg bg-yellow/10 border border-yellow/20">
+                <WarningIcon className="size-5 shrink-0 text-yellow-dark" weight="fill" />
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  <p className="text-xs leading-tight text-gray-100">{notification.message}</p>
+                  <button
+                    type="button"
+                    onClick={notification.onAction}
+                    className="self-start text-xs font-medium text-primary hover:underline"
+                  >
+                    {notification.actionLabel}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
           {storage && (
             <SidenavStorage
               usage={storage.usage}

--- a/src/components/navigation/sidenav/Sidenav.tsx
+++ b/src/components/navigation/sidenav/Sidenav.tsx
@@ -39,6 +39,7 @@ export interface SidenavProps {
   showSubsections?: boolean;
   isCollapsed?: boolean;
   storage?: SidenavStorageProps;
+  notification?: ReactNode;
   onToggleCollapse?: () => void;
 }
 
@@ -55,6 +56,7 @@ export interface SidenavProps {
  * @property {boolean} showSubsections - Determines whether to display the subsections of the sidenav
  * @property {boolean} isCollapsed - Determines whether the sidenav is collapsed or not
  * @property {SidenavStorage} storage - The storage information displayed at the bottom of the sidenav
+ * @property {ReactNode} notification - Optional notification node rendered above the storage section (hidden when collapsed)
  * @property {() => void} onToggleCollapse - A callback function triggered when the collapse button is clicked
  */
 const Sidenav = ({
@@ -66,6 +68,7 @@ const Sidenav = ({
   showSubsections,
   isCollapsed = false,
   storage,
+  notification,
   onToggleCollapse,
 }: SidenavProps) => {
   return (
@@ -94,18 +97,21 @@ const Sidenav = ({
         </div>
       </div>
 
-      {storage && (
+      {(notification || storage) && (
         <div
-          className={`transition-all overflow-hidden duration-300 ${isCollapsed ? 'opacity-0 invisible delay-200' : 'opacity-100 delay-0'}`}
+          className={`flex flex-col transition-all overflow-hidden duration-300 ${isCollapsed ? 'opacity-0 invisible delay-200' : 'opacity-100 delay-0'}`}
         >
-          <SidenavStorage
-            usage={storage.usage}
-            limit={storage.limit}
-            percentage={storage.percentage}
-            onUpgradeClick={storage.onUpgradeClick}
-            upgradeLabel={storage.upgradeLabel}
-            isLoading={storage.isLoading}
-          />
+          {notification && <div className="px-2 pb-2">{notification}</div>}
+          {storage && (
+            <SidenavStorage
+              usage={storage.usage}
+              limit={storage.limit}
+              percentage={storage.percentage}
+              onUpgradeClick={storage.onUpgradeClick}
+              upgradeLabel={storage.upgradeLabel}
+              isLoading={storage.isLoading}
+            />
+          )}
         </div>
       )}
     </div>

--- a/src/components/navigation/sidenav/__test__/Sidenav.test.tsx
+++ b/src/components/navigation/sidenav/__test__/Sidenav.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import Sidenav, { SidenavProps } from '../Sidenav';
@@ -217,7 +217,7 @@ describe('Sidenav Component', () => {
     });
 
     it('hides storage when collapsed', () => {
-      const { getByText } = renderSidenav({
+      const { queryByText } = renderSidenav({
         isCollapsed: true,
         storage: {
           usage: '2.8 GB',
@@ -228,10 +228,8 @@ describe('Sidenav Component', () => {
           isLoading: false,
         },
       });
-      const usageText = getByText('2.8 GB');
-      const storageContainer = usageText.closest('div')?.parentElement?.parentElement?.parentElement;
-      expect(storageContainer).toHaveClass('opacity-0');
-      expect(storageContainer).toHaveClass('invisible');
+      expect(queryByText('2.8 GB')).not.toBeInTheDocument();
+      expect(queryByText('4 GB')).not.toBeInTheDocument();
     });
 
     it('hides subsections when collapsed even if showSubsections is true', () => {
@@ -257,6 +255,64 @@ describe('Sidenav Component', () => {
       const { container } = renderSidenav({ isCollapsed: true });
       const optionButtons = container.querySelectorAll('button[title="Inbox"]');
       expect(optionButtons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Notification', () => {
+    const onAction = vi.fn();
+    const notification = {
+      message: 'Your account will be deleted in 14 days.',
+      actionLabel: 'Upgrade plan',
+      onAction,
+    };
+
+    it('should match snapshot with notification', () => {
+      const { container } = renderSidenav({ notification });
+      expect(container).toMatchSnapshot();
+    });
+
+    it('renders notification message and action label', () => {
+      const { getByText } = renderSidenav({ notification });
+      expect(getByText('Your account will be deleted in 14 days.')).toBeInTheDocument();
+      expect(getByText('Upgrade plan')).toBeInTheDocument();
+    });
+
+    it('calls onAction when action button is clicked', () => {
+      const { getByText } = renderSidenav({ notification });
+      fireEvent.click(getByText('Upgrade plan'));
+      expect(onAction).toHaveBeenCalledOnce();
+    });
+
+    it('does not render notification when isCollapsed is true', () => {
+      const { queryByText } = renderSidenav({ notification, isCollapsed: true });
+      expect(queryByText('Your account will be deleted in 14 days.')).not.toBeInTheDocument();
+    });
+
+    it('hides notification immediately when sidenav collapses', () => {
+      vi.useFakeTimers();
+      const { getByText, queryByText, rerender } = renderSidenav({ notification, isCollapsed: false });
+      expect(getByText('Your account will be deleted in 14 days.')).toBeInTheDocument();
+
+      rerender(<Sidenav {...defaultProps} notification={notification} isCollapsed={true} />);
+      expect(queryByText('Your account will be deleted in 14 days.')).not.toBeInTheDocument();
+
+      vi.useRealTimers();
+    });
+
+    it('shows notification after 300ms when sidenav expands', () => {
+      vi.useFakeTimers();
+      const { getByText, queryByText, rerender } = renderSidenav({ notification, isCollapsed: true });
+      expect(queryByText('Your account will be deleted in 14 days.')).not.toBeInTheDocument();
+
+      rerender(<Sidenav {...defaultProps} notification={notification} isCollapsed={false} />);
+      expect(queryByText('Your account will be deleted in 14 days.')).not.toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(getByText('Your account will be deleted in 14 days.')).toBeInTheDocument();
+
+      vi.useRealTimers();
     });
   });
 

--- a/src/components/navigation/sidenav/__test__/__snapshots__/Sidenav.test.tsx.snap
+++ b/src/components/navigation/sidenav/__test__/__snapshots__/Sidenav.test.tsx.snap
@@ -717,7 +717,7 @@ exports[`Sidenav Component > should match snapshot with storage 1`] = `
       </div>
     </div>
     <div
-      class="transition-all overflow-hidden duration-300 opacity-100 delay-0"
+      class="flex flex-col transition-all overflow-hidden duration-300 opacity-100 delay-0"
     >
       <div
         class="flex flex-col w-full gap-2.5 px-2 pb-5"

--- a/src/components/navigation/sidenav/__test__/__snapshots__/Sidenav.test.tsx.snap
+++ b/src/components/navigation/sidenav/__test__/__snapshots__/Sidenav.test.tsx.snap
@@ -1,5 +1,215 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Sidenav Component > Notification > should match snapshot with notification 1`] = `
+<div>
+  <div
+    class="relative flex flex-col p-2 h-full justify-between bg-gray-1 border-r border-gray-10 transition-all duration-300 group w-64"
+  >
+    <div
+      class="flex flex-col"
+    >
+      <div
+        class="flex flex-row justify-between w-full py-5 px-2 undefined"
+      >
+        <div
+          class="relative flex flex-row gap-2 items-center"
+        >
+          <button
+            class="flex flex-row gap-2 items-center"
+          >
+            <img
+              alt="Mail"
+              class="flex-shrink-0 min-w-[28px] min-h-[28px] "
+              height="28"
+              src="https://example.com/logo.png"
+              width="28"
+            />
+            <p
+              class="text-xl font-medium text-gray-100 whitespace-nowrap"
+            >
+              Mail
+            </p>
+          </button>
+        </div>
+        <div
+          class="flex z-20 flex-row gap-2 items-center transition-opacity duration-100 opacity-100"
+        />
+      </div>
+      <div
+        class="flex flex-col gap-4 overflow-hidden"
+      >
+        <div
+          class="relative"
+        >
+          <div
+            class="transition-opacity duration-300 opacity-100"
+          />
+        </div>
+        <div
+          class="flex flex-col w-full"
+        >
+          <button
+            class="flex w-full flex-col overflow-hidden focus-visible:bg-gray-10 rounded-lg hover:bg-gray-5 "
+            data-cy="inbox"
+          >
+            <div
+              class="flex flex-row px-2.5 py-2 w-full items-center justify-between min-h-[36px]"
+            >
+              <div
+                class="flex flex-row gap-3 items-center text-gray-80"
+              >
+                <svg
+                  data-testid="mock-icon"
+                  height="20"
+                  width="20"
+                />
+                <p
+                  class="font-medium whitespace-nowrap overflow-hidden transition-all duration-300 opacity-100 delay-0"
+                >
+                  Inbox
+                </p>
+              </div>
+              <div
+                class="flex rounded-full px-2 py-1 transition-all duration-300 bg-gray-10 text-gray-60 opacity-100 delay-0"
+              >
+                <p
+                  class="text-xs font-medium"
+                >
+                  5
+                </p>
+              </div>
+            </div>
+          </button>
+          <button
+            class="flex w-full flex-col overflow-hidden focus-visible:bg-gray-10 rounded-lg hover:bg-gray-5 "
+            data-cy="sent"
+          >
+            <div
+              class="flex flex-row px-2.5 py-2 w-full items-center justify-between min-h-[36px]"
+            >
+              <div
+                class="flex flex-row gap-3 items-center text-gray-80"
+              >
+                <svg
+                  data-testid="mock-icon"
+                  height="20"
+                  width="20"
+                />
+                <p
+                  class="font-medium whitespace-nowrap overflow-hidden transition-all duration-300 opacity-100 delay-0"
+                >
+                  Sent
+                </p>
+              </div>
+              <div
+                class="flex rounded-full px-2 py-1 transition-all duration-300 bg-gray-10 text-gray-60 opacity-0 invisible delay-300"
+              />
+            </div>
+          </button>
+          <button
+            class="flex w-full flex-col overflow-hidden focus-visible:bg-gray-10 rounded-lg hover:bg-gray-5 "
+            data-cy="drafts"
+          >
+            <div
+              class="flex flex-row px-2.5 py-2 w-full items-center justify-between min-h-[36px]"
+            >
+              <div
+                class="flex flex-row gap-3 items-center text-gray-80"
+              >
+                <svg
+                  data-testid="mock-icon"
+                  height="20"
+                  width="20"
+                />
+                <p
+                  class="font-medium whitespace-nowrap overflow-hidden transition-all duration-300 opacity-100 delay-0"
+                >
+                  Drafts
+                </p>
+              </div>
+              <div
+                class="flex rounded-full px-2 py-1 transition-all duration-300 bg-gray-10 text-gray-60 opacity-100 delay-0"
+              >
+                <p
+                  class="text-xs font-medium"
+                >
+                  2
+                </p>
+              </div>
+            </div>
+          </button>
+          <button
+            class="flex w-full flex-col overflow-hidden focus-visible:bg-gray-10 rounded-lg hover:bg-gray-5 "
+            data-cy="labels"
+          >
+            <div
+              class="flex flex-row px-2.5 py-2 w-full items-center justify-between min-h-[36px]"
+            >
+              <div
+                class="flex flex-row gap-3 items-center text-gray-80"
+              >
+                <svg
+                  data-testid="mock-icon"
+                  height="20"
+                  width="20"
+                />
+                <p
+                  class="font-medium whitespace-nowrap overflow-hidden transition-all duration-300 opacity-100 delay-0"
+                >
+                  Labels
+                </p>
+              </div>
+              <div
+                class="flex rounded-full px-2 py-1 transition-all duration-300 bg-gray-10 text-gray-60 opacity-0 invisible delay-300"
+              />
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex flex-col"
+    >
+      <div
+        class="px-2 pb-2"
+      >
+        <div
+          class="flex gap-1.5 items-start p-3 rounded-lg bg-yellow/10 border border-yellow/20"
+        >
+          <svg
+            class="size-5 shrink-0 text-yellow-dark"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 256 256"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M236.8,188.09,149.35,36.22h0a24.76,24.76,0,0,0-42.7,0L19.2,188.09a23.51,23.51,0,0,0,0,23.72A24.35,24.35,0,0,0,40.55,224h174.9a24.35,24.35,0,0,0,21.33-12.19A23.51,23.51,0,0,0,236.8,188.09ZM120,104a8,8,0,0,1,16,0v40a8,8,0,0,1-16,0Zm8,88a12,12,0,1,1,12-12A12,12,0,0,1,128,192Z"
+            />
+          </svg>
+          <div
+            class="flex flex-col gap-0.5 min-w-0"
+          >
+            <p
+              class="text-xs leading-tight text-gray-100"
+            >
+              Your account will be deleted in 14 days.
+            </p>
+            <button
+              class="self-start text-xs font-medium text-primary hover:underline"
+              type="button"
+            >
+              Upgrade plan
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Sidenav Component > should match snapshot 1`] = `
 <div>
   <div
@@ -717,7 +927,7 @@ exports[`Sidenav Component > should match snapshot with storage 1`] = `
       </div>
     </div>
     <div
-      class="flex flex-col transition-all overflow-hidden duration-300 opacity-100 delay-0"
+      class="flex flex-col"
     >
       <div
         class="flex flex-col w-full gap-2.5 px-2 pb-5"


### PR DESCRIPTION
Adds an optional `notification` prop to Sidenav, rendered between the options list and the storage section. The slot inherits the existing collapse transition so it auto-hides when the sidenav is collapsed.


<img width="1992" height="1125" alt="imagen" src="https://github.com/user-attachments/assets/f8f3ceba-ef66-4569-841a-8555d0328cc3" />

