### PR TITLE
fix: use npm publish in GitHub registry workflow

### DIFF
--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -30,6 +30,6 @@ jobs:
         run: yarn build
 
       - name: Publish to GitHub
-        run: yarn publish
+        run: npm publish --scope=@internxt --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- `yarn publish` en CI pide confirmación interactiva de versión → el job falla silenciosamente
- Cambiado a `npm publish --scope=@internxt --access public`, igual que el workflow de npm.org

## Test plan
- [ ] Re-ejecutar el workflow "Publish UI package to GitHub registry" para v0.1.20 tras mergear
- [ ] Verificar que el paquete aparece en GitHub Packages con versión 0.1.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)